### PR TITLE
feat configs: don't duplicate dbconnection in config_vars, pass it through env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,12 @@ format:
 	find src -name '*pp' -type f | xargs $(CLANG_FORMAT) -i
 	find tests -name '*.py' -type f | xargs autopep8 -i
 
+# Set environment for --in-docker-start
+export DB_CONNECTION := postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@service-postgres:5432/${POSTGRES_DB}
+
 # Internal hidden targets that are used only in docker environment
 --in-docker-start-debug --in-docker-start-release: --in-docker-start-%: install-%
-	psql 'postgresql://user:password@service-postgres:5432/pg_grpc_service_template_db_1' -f ./postgresql/data/initial_data.sql
+	psql ${DB_CONNECTION} -f ./postgresql/data/initial_data.sql
 	/home/user/.local/bin/pg_grpc_service_template \
 		--config /home/user/.local/etc/pg_grpc_service_template/static_config.yaml \
 		--config_vars /home/user/.local/etc/pg_grpc_service_template/config_vars.docker.yaml
@@ -79,7 +82,7 @@ format:
 # Build and run service in docker environment
 .PHONY: docker-start-service-debug docker-start-service-release
 docker-start-service-debug docker-start-service-release: docker-start-service-%:
-	$(DOCKER_COMPOSE) run -p 8080:8080 --rm pg_grpc_service_template-container make -- --in-docker-start-$*
+	$(DOCKER_COMPOSE) run -p 8080:8080 -p 8081:8081 --rm pg_grpc_service_template-container make -- --in-docker-start-$*
 
 # Start targets makefile in docker environment
 .PHONY: docker-cmake-debug docker-build-debug docker-test-debug docker-clean-debug docker-install-debug docker-cmake-release docker-build-release docker-test-release docker-clean-release docker-install-release

--- a/configs/config_vars.docker.yaml
+++ b/configs/config_vars.docker.yaml
@@ -9,5 +9,3 @@ server-port: 8080
 server-grpc-port: 8081
 
 hello-endpoint: '[::1]:8081'
-
-dbconnection: 'postgresql://user:password@service-postgres:5432/pg_grpc_service_template_db_1'

--- a/configs/static_config.yaml
+++ b/configs/static_config.yaml
@@ -76,6 +76,7 @@ components_manager:
 
         postgres-db-1:
             dbconnection: $dbconnection
+            dbconnection#env: DB_CONNECTION
             blocking_task_processor: fs-task-processor
             dns_resolver: async
             sync-start: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     postgres:
         container_name: service-postgres
         image: postgres:12
-        environment:
-          - POSTGRES_DB=pg_grpc_service_template_db_1
-          - POSTGRES_USER=user
-          - POSTGRES_PASSWORD=password
+        environment: &db_env
+          POSTGRES_DB: pg_grpc_service_template_db_1
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
         ports:
           - 5432
         volumes:
@@ -20,12 +20,10 @@ services:
         image: ghcr.io/userver-framework/ubuntu-22.04-userver-pg:latest
         privileged: true
         environment:
-          - POSTGRES_DB=pg_grpc_service_template_db_1
-          - POSTGRES_USER=user
-          - POSTGRES_PASSWORD=password
-          - PREFIX=${PREFIX:-~/.local}
-          - CCACHE_DIR=/pg_grpc_service_template/.ccache
-          - CORES_DIR=/cores
+          <<: *db_env
+          PREFIX: ${PREFIX:-~/.local}
+          CCACHE_DIR: /pg_grpc_service_template/.ccache
+          CORES_DIR: /cores
         volumes:
           - .:/pg_grpc_service_template:rw
           - ${TC_CORES_DIR:-./.cores}:/cores:rw


### PR DESCRIPTION
Add feature from [my pg_service_template PR](https://github.com/userver-framework/pg_service_template/pull/54)

Attempt to fix problem with port mapping in docker-compose in Makefile (in original version service in unavailable when call it from local grpc stub)